### PR TITLE
Add $QT_IMPORT_QML/LunaWebEngineViewStyle as an import path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ find_package(Qt5Qml REQUIRED)
 find_package(Qt5Quick REQUIRED)
 find_package(Qt5WebEngine REQUIRED)
 
+add_definitions(-DQT_INSTALL_QML="${OE_QMAKE_PATH_QML}")
+
 find_package(PkgConfig "0.22" REQUIRED)
 
 pkg_check_modules(GLIB2 glib-2.0 REQUIRED)

--- a/src/lunaqmlapplication.cpp
+++ b/src/lunaqmlapplication.cpp
@@ -199,6 +199,7 @@ bool LunaQmlApplication::setup(const QString& applicationBasePath, const QUrl& p
     }
 
     mEngine.addImportPath(applicationBasePath);
+    mEngine.addImportPath(QT_INSTALL_QML "/LunaWebEngineViewStyle");
 
     mEngine.rootContext()->setContextProperty("application", this);
 


### PR DESCRIPTION
This allow us to overload the QML definition of the UIDelegates of the
WebEngineView instances.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>