### PR TITLE
Correctly setup the webos application service handle

### DIFF
--- a/files/sysbus/luna-qml-launcher.manifest.json
+++ b/files/sysbus/luna-qml-launcher.manifest.json
@@ -1,0 +1,14 @@
+{
+    "id": "luna-qml-launcher",
+    "version": "1.0.0",
+    "roleFiles": [
+        "/usr/share/luna-service2/roles.d/org.webosports.luna-qml-launcher.role.json"
+    ],
+    "serviceFiles": [
+    ],
+    "apiPermissionFiles": [
+    ],
+    "clientPermissionFiles": [
+        "/usr/share/luna-service2/client-permissions.d/org.webosports.luna-qml-launcher.perm.json"
+    ]
+}

--- a/files/sysbus/org.webosports.luna-qml-launcher.container.json.in
+++ b/files/sysbus/org.webosports.luna-qml-launcher.container.json.in
@@ -1,3 +1,0 @@
-{
-	"exeNames": ["@WEBOS_INSTALL_SBINDIR@/luna-qml-launcher"]
-}

--- a/files/sysbus/org.webosports.luna-qml-launcher.perm.json
+++ b/files/sysbus/org.webosports.luna-qml-launcher.perm.json
@@ -1,14 +1,10 @@
 {
-    "org.webosports.*": [
-        "all"
-    ],
-    "com.palm.*": [
-        "all"
-    ],
-    "": [
-        "all"
-    ],
-    "*": [
-        "all"
+    "org.webosports.luna-qml-launcher-*": [
+        "applications",
+        "devices",
+        "services",
+        "settings",
+        "system",
+        "private", "public"
     ]
 }

--- a/files/sysbus/org.webosports.luna-qml-launcher.role.json.in
+++ b/files/sysbus/org.webosports.luna-qml-launcher.role.json.in
@@ -1,27 +1,10 @@
 {
     "exeName":"@WEBOS_INSTALL_SBINDIR@/luna-qml-launcher",
     "type": "privileged",
-    "allowedNames": ["*", "", "org.webosports.*", "com.palm.*"],
+    "allowedNames": ["org.webosports.luna-qml-launcher-*"],
     "permissions": [
         {
-            "service":"qtpositioning_*",
-            "inbound":["org.webosports.service.location"],
-            "outbound":["org.webosports.service.location"]
-        },
-        {
-            "service":"org.webosports.*",
-            "outbound":["*"]
-        },
-        {
-            "service":"com.palm.*",
-            "outbound":["*"]
-        },
-        {
-            "service":"*",
-            "outbound":["*"]
-        },
-        {
-            "service":"",
+            "service":"org.webosports.luna-qml-launcher-*",
             "outbound":["*"]
         }
     ]

--- a/src/lunaqmlapplication.cpp
+++ b/src/lunaqmlapplication.cpp
@@ -121,11 +121,16 @@ int LunaQmlApplication::launchApp()
         QtWebEngine::initialize();
     }
 
+    // The main service handle is the one for luna-qml-launcher, not the one of the QML app.
+    // The service handle of the app will be managed afterwards by LunaService QML plugin.
+    QString qmlLauncherAppId = "org.webosports.luna-qml-launcher-" + QString::number(QCoreApplication::applicationPid());
+
+    webos_application_init(mAppDescription->getId().toUtf8().constData(), qmlLauncherAppId.toUtf8().constData(), &event_handlers, this);
+    webos_application_attach(g_main_loop_new(g_main_context_default(), TRUE));
+
+    // Now load the QML app
     if (!setup(applicationBasePath, mAppDescription->getEntryPoint()))
         return -1;
-
-    webos_application_init(mAppDescription->getId().toUtf8().constData(), &event_handlers, this);
-    webos_application_attach(g_main_loop_new(g_main_context_default(), TRUE));
 
     return this->exec();
 }


### PR DESCRIPTION
As the QML launcher is acting as a container, its permissions won't
necessarily match the permissions required for the apps.

Therefore, the main service handle of the launcher has to be done under a
dedicated name.
The app LS2 call will then be handled by the LunaService QML plugin.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>