### PR TITLE
lunaqmlapplication.cpp: Set QML_XHR_ALLOW_FILE_READ environment variable

### DIFF
--- a/src/lunaqmlapplication.cpp
+++ b/src/lunaqmlapplication.cpp
@@ -104,6 +104,9 @@ int LunaQmlApplication::launchApp()
 
     mHeadless = mAppDescription->isHeadLess();
 
+    // We want to make sure we can still use XHR for loading local files at our end in our QML apps.
+    qputenv("QML_XHR_ALLOW_FILE_READ", QByteArray("1"));
+    
     if (mAppDescription->useLuneOSStyle())
         setenv("QT_QUICK_CONTROLS_STYLE", "LuneOS", 1);
 


### PR DESCRIPTION
So we can keep loading local files in newer Qt. 

Solves: "XMLHttpRequest: Using GET on a local file is dangerous and will be disabled by default in a future Qt version. Set QML_XHR_ALLOW_FILE_READ to 1 if you wish to continue using this feature."

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>